### PR TITLE
memos: removed dependency on angular2-gwt:1.7-SNAPSHOT

### DIFF
--- a/memos/pom.xml
+++ b/memos/pom.xml
@@ -14,15 +14,6 @@
 	<name>angular2gwt-memos</name>
 	<packaging>jar</packaging>
 
-	<dependencies>
-		<dependency>
-			<groupId>fr.lteconsulting</groupId>
-			<artifactId>angular2-gwt</artifactId>
-			<version>1.7-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
angular2-gwt:1.7-SNAPSHOT dependency shouldn't be necessary since angular2-gwt:1.7 is available.
Removing this deoendency allows building the demos project on its own, w/o installing angular2-gwt:1.7-SNAPSHOT locally.
